### PR TITLE
[FIX] Fixes crash when pattern is larger than contig seq for omp-enabled

### DIFF
--- a/include/seqan/index/find_pigeonhole.h
+++ b/include/seqan/index/find_pigeonhole.h
@@ -1115,7 +1115,7 @@ windowFindNext(
     // iterate over all non-repeat regions within the window
     for (; finder.curPos < windowEnd; )
     {
-        THstkPos nonRepeatEnd = finder.endPos - length(pattern.shape) + 1;
+        THstkPos nonRepeatEnd = finder.endPos - _min(finder.endPos, length(pattern.shape) + 1);
         THstkPos localEnd = _min(windowEnd, nonRepeatEnd);
 
         // filter a non-repeat region within the window


### PR DESCRIPTION
## Comments from https://github.com/seqan/seqan/pull/2298 for posterity

This fixes the crash where the region end index underflows and the child fork thinks there's still more results to report back in https://github.com/deepgenomics/seqan/blob/584ae4fbff8312cfe31b3e0aea651edfb1b580ef/apps/razers3/razers_parallel.h#L736-L738

now it will err log 
```
ERROR: windowFindBegin() failed in thread 0
```
and report no hits. The logic can probably be further simplified for https://github.com/deepgenomics/seqan/blob/584ae4fbff8312cfe31b3e0aea651edfb1b580ef/apps/razers3/razers_parallel.h#L664-L667

to have
```cpp
hasMore = windowFindBegin(...);
windowsDone += hasMore ? 0 : 1;
```

but I'm unsure as to whether the err has utility.